### PR TITLE
Fix default YOLO model path

### DIFF
--- a/webapi/app.py
+++ b/webapi/app.py
@@ -55,8 +55,11 @@ except Exception as e:
     print(f"[ERROR] Failed to initialize enhanced audio processor: {e}")
     enhanced_audio_processor = None
 
-#Models & Consts  
-MODEL_PATH   = os.getenv("MODEL_PATH") or "yolov8n.pt"
+# Models & Consts
+MODEL_PATH = os.getenv("MODEL_PATH")
+if not MODEL_PATH:
+    # Default to the bundled model relative to this file
+    MODEL_PATH = os.path.join(Path(__file__).resolve().parent, "best.pt")
 emotion_model = YOLO(MODEL_PATH)
 
 whisper_model = whisper.load_model("turbo", device=DEVICE) 


### PR DESCRIPTION
## Summary
- fix YOLO model default path so the bundled `best.pt` model loads correctly

## Testing
- `python -m py_compile webapi/*.py`
- `npm install --silent`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_685630b9768c8330997356cab6bc73da